### PR TITLE
feat: Add Table of Contents generation to READMEGenerator

### DIFF
--- a/src/readme-generator.js
+++ b/src/readme-generator.js
@@ -8,6 +8,16 @@ class READMEGenerator {
         this.content = '';
     }
 
+    generateTOC() {
+        this.content += '## Table of Contents\n';
+        this.content += '- [Description](#description)\n';
+        this.content += '- [Installation](#installation)\n';
+        this.content += '- [Usage](#usage)\n';
+        this.content += '- [License](#license)\n';
+        this.content += '- [Contributors](#contributors)\n';
+        this.content += '- [Tests](#tests)\n';
+    }
+
     create() {
         fs.writeFile(this.name, this.content, (err) => {
             if (err) {
@@ -21,7 +31,8 @@ class READMEGenerator {
         // Ask the user for information
         // call the corresponding function to generate the content
         // When all the information is collected, call the create function to generate the README.md file
-
+        this.generateTOC();
+        this.create();
     }
 }
 

--- a/test/readme-generator.test.js
+++ b/test/readme-generator.test.js
@@ -18,4 +18,38 @@ describe('README Generator', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
+
+    it("should generate the README Table of Contents", () => {
+        const generator = new READMEGenerator("./test/");
+        generator.generateTOC();
+        expect(generator.content).toContain('## Table of Contents\n');
+        expect(generator.content).toContain('- [Description](#description)\n');
+        expect(generator.content).toContain('- [Installation](#installation)\n');
+        expect(generator.content).toContain('- [Usage](#usage)\n');
+        expect(generator.content).toContain('- [License](#license)\n');
+        expect(generator.content).toContain('- [Contributors](#contributors)\n');
+        expect(generator.content).toContain('- [Tests](#tests)\n');
+    });
+
+    it("should call fs.writeFile with correct arguments when create is called", () => {
+        const generator = new READMEGenerator();
+        generator.content = "Sample content";
+        generator.create();
+        expect(fs.writeFile).toHaveBeenCalledWith(
+            "./README.md",
+            "Sample content",
+            expect.any(Function)
+        );
+    });
+
+    it("should run the generateTOC and create methods when run is called", async () => {
+        const generator = new READMEGenerator();
+        const generateTOCSpy = jest.spyOn(generator, "generateTOC");
+        const createSpy = jest.spyOn(generator, "create");
+
+        await generator.run();
+
+        expect(generateTOCSpy).toHaveBeenCalled();
+        expect(createSpy).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
- Implemented generateTOC method to create a structured Table of Contents in the README file.
- Updated run method to include the generateTOC method.
- Added tests to verify the correct generation of Table of Contents.
- Ensured fs.writeFile is called with appropriate arguments during creation.
- Maintained and expanded Jest test coverage to validate the new functionality.